### PR TITLE
Cover module/class name having `_` and/or `numbers`

### DIFF
--- a/syntaxes/rbs.tmLanguage.json
+++ b/syntaxes/rbs.tmLanguage.json
@@ -22,7 +22,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.class.rbs",
-					"match": "\\b(class)\\s+([A-Z][a-zA-Z]*)",
+					"match": "\\b(class)\\s+([A-Z][a-zA-Z0-9_]*)",
 					"captures": {
 						"1": {
 							"name": "keyword.control.class.rbs"
@@ -126,7 +126,7 @@
 				},
 				{
 					"name": "keyword.control.module.rbs",
-					"match": "\\b(module)\\s+([A-Z][a-zA-Z]*)",
+					"match": "\\b(module)\\s+([A-Z][a-zA-Z0-9_]*)",
 					"captures": {
 						"1": {
 							"name": "keyword.control.module.rbs"


### PR DESCRIPTION
Hi! I found this issue in https://github.com/kachick/ruby-ulid/blob/2bf89942bdb7e57756f7ebc7d88e0a1037c952cd/sig/ulid.rbs#L38

I know, this change is not perfect for Ruby/rbs syntax, especially does not cover `日本語`.
But containing `_` and numbers are common use-case, so I think adding this might better 🙏 

Before
---

<img width="224" alt="スクリーンショット 2021-05-29 21 23 03" src="https://user-images.githubusercontent.com/1180335/120070750-003db100-c0c7-11eb-9be8-a77e9b2af70a.png">

After
---

<img width="235" alt="スクリーンショット 2021-05-29 21 38 58" src="https://user-images.githubusercontent.com/1180335/120070751-016ede00-c0c7-11eb-9a69-8104672b8468.png">

