### PR TITLE
Support absolute type name

### DIFF
--- a/syntaxes/rbs.tmLanguage.json
+++ b/syntaxes/rbs.tmLanguage.json
@@ -22,7 +22,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.class.rbs",
-					"match": "\\b(class)\\s+([A-Z]\\w*)",
+					"match": "\\b(class)\\s+((::)?([A-Z]\\w*(::))*[A-Z]\\w*)",
 					"captures": {
 						"1": {
 							"name": "keyword.control.class.rbs"
@@ -86,7 +86,7 @@
 				},
 				{
 					"name": "keyword.control.interface.rbs",
-					"match": "\\b(interface)\\s+(_[A-Z]\\w*)",
+					"match": "\\b(interface)\\s+((::)?([A-Z]\\w*(::))*_[A-Z]\\w*)",
 					"captures": {
 						"1": {
 							"name": "keyword.control.interface.rbs"
@@ -102,7 +102,7 @@
 				},
 				{
 					"name": "keyword.control.include.rbs",
-					"match": "\\b(include)\\s+(_?[A-Z]\\w*)",
+					"match": "\\b(include)\\s+((::)?([A-Z]\\w*(::))*_?[A-Z]\\w*)",
 					"captures": {
 						"1": {
 							"name": "keyword.control.include.rbs"
@@ -114,7 +114,7 @@
 				},
 				{
 					"name": "keyword.control.extend.rbs",
-					"match": "\\b(extend)\\s+(_?[A-Z]\\w*)",
+					"match": "\\b(extend)\\s+((::)?([A-Z]\\w*(::))*_?[A-Z]\\w*)",
 					"captures": {
 						"1": {
 							"name": "keyword.control.extend.rbs"
@@ -126,7 +126,7 @@
 				},
 				{
 					"name": "keyword.control.prepend.rbs",
-					"match": "\\b(prepend)\\s+([A-Z]\\w*)",
+					"match": "\\b(prepend)\\s+((::)?([A-Z]\\w*(::))*[A-Z]\\w*)",
 					"captures": {
 						"1": {
 							"name": "keyword.control.prepend.rbs"
@@ -138,7 +138,7 @@
 				},
 				{
 					"name": "keyword.control.module.rbs",
-					"match": "\\b(module)\\s+([A-Z]\\w*)",
+					"match": "\\b(module)\\s+((::)?([A-Z]\\w*(::))*[A-Z]\\w*)",
 					"captures": {
 						"1": {
 							"name": "keyword.control.module.rbs"


### PR DESCRIPTION
I fixed coloring when a class or module name is an absolute path beginning with `::`.

### Before

<img width="258" alt="image" src="https://github.com/soutaro/vscode-rbs-syntax/assets/935310/8913257a-b245-4a46-9bc0-4ed4a52ab2cb">

### After

<img width="270" alt="image" src="https://github.com/soutaro/vscode-rbs-syntax/assets/935310/c0994ee5-2fc5-427b-8771-2f709dbe5d66">

note: `prepend` does not support interface.